### PR TITLE
fix: APIキャッシュ無効化でカード金額が加算されない問題を修正

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -221,8 +221,8 @@ async function loadBadges() {
   } catch (e) { console.error(e); }
 }
 
-async function api(url, options) {
-  const res = await fetch(url, options);
+async function api(url, options = {}) {
+  const res = await fetch(url, { cache: 'no-store', ...options });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.error || `HTTPエラー ${res.status}`);

--- a/server.js
+++ b/server.js
@@ -6,6 +6,10 @@ const app = express();
 const db = new Database(path.join(__dirname, 'budget.db'));
 
 app.use(express.json());
+app.use('/api', (req, res, next) => {
+  res.set('Cache-Control', 'no-store');
+  next();
+});
 app.use(express.static(path.join(__dirname, 'public')));
 
 db.exec(`


### PR DESCRIPTION
ブラウザによるGETレスポンスのキャッシュが原因でカードが更新されなかった。server.jsにCache-Control: no-storeを追加し、fetch側にもcache: no-storeを指定した。